### PR TITLE
Send static files as bytes

### DIFF
--- a/gren.json
+++ b/gren.json
@@ -11,7 +11,7 @@
     "gren-version": "0.3.0 <= v < 0.4.0",
     "dependencies": {
         "gren-lang/core": "4.0.0 <= v < 5.0.0",
-        "gren-lang/node": "3.0.1 <= v < 4.0.0",
+        "gren-lang/node": "3.1.0 <= v < 4.0.0",
         "gren-lang/url": "3.0.0 <= v < 3.0.1"
     }
 }

--- a/src/Server/Static.gren
+++ b/src/Server/Static.gren
@@ -142,28 +142,6 @@ readFileAsBytes fsPermission fileName =
                 )
 
 
-{-| Read a file from disk as `String`.
--}
-readFileAsString : FileSystem.Permission -> String -> Task ReadFileError String
-readFileAsString fsPermission fileName =
-    let
-        fileBytesToString : Bytes -> Maybe String
-        fileBytesToString bytes =
-            Bytes.Decode.decode (Bytes.Decode.string (Bytes.width bytes)) bytes
-    in
-    readFileAsBytes fsPermission fileName
-        |> Task.map fileBytesToString
-        |> Task.andThen
-                (\result ->
-                    let
-                        err =
-                            UnknownFileSystemError (FileSystem.UnknownFileSystemError "")
-                    in
-                    Maybe.map Task.succeed result
-                        |> Maybe.withDefault (Task.fail err)
-                )
-
-
 {-| Take the passed path (and an optional modifier), try to find a file at that path, and 
 produce a `Response` if it can be found.
 -}
@@ -192,7 +170,7 @@ staticFileResponse { directory, httpResponse, fileSystemPermission } passedPath 
         |> FileSystem.buildPath
         |> FileSystem.normalizePath
         -- Attempt to take the path and get a file from it on the file system 
-        |> readFileAsString fileSystemPermission
+        |> readFileAsBytes fileSystemPermission
         |> Task.map
                 (\body ->
                     -- If it succeeds, produce a 200 (OK) response with the body set to 
@@ -200,7 +178,7 @@ staticFileResponse { directory, httpResponse, fileSystemPermission } passedPath 
                     httpResponse
                         |> HttpServer.Response.setHeader "Content-Type" mimeType
                         |> HttpServer.Response.setStatus 200
-                        |> HttpServer.Response.setBody body
+                        |> HttpServer.Response.setBodyAsBytes body
                 )
 
 


### PR DESCRIPTION
Converting to string was causing image corruption. This bumps gren-lang/node to 3.1.0 to use the new `Response.setBodyAsBytes` added in https://github.com/gren-lang/node/pull/11