### PR TITLE
Add wasm mime type.

### DIFF
--- a/src/MimeType.gren
+++ b/src/MimeType.gren
@@ -210,6 +210,9 @@ mimeTypes =
         , { key = "vsd"
           , value = "application/vnd.visio"
           }
+        , { key = "wasm"
+          , value = "application/wasm"
+          }
         , { key = "wav"
           , value = "audio/wav"
           }


### PR DESCRIPTION
.wasm files were being sent as `application/octet-stream`, causing them to be blocked.

This change sends them as `application/wasm`, which is what's expected in the major browsers according to https://webassembly.org/docs/web/